### PR TITLE
Parse MapArrays from parquet files without schema metadata

### DIFF
--- a/src/io/parquet/read/schema/convert.rs
+++ b/src/io/parquet/read/schema/convert.rs
@@ -297,6 +297,10 @@ fn to_group_type(
     debug_assert!(!fields.is_empty());
     if field_info.repetition == Repetition::Repeated {
         if (field_info.name == "key_value" || field_info.name == "map") && fields.len() == 2 {
+            // For map types, the middle level, named key_value, is a repeated group with "key_value" as the name
+            // and two fields, "key" and "value". The "key" field is the key type and the "value" field is the value type.
+            // For backward compatibility, the "key_value" group may be named "map" instead of "key_value".
+            // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#maps
             to_struct(fields, options)
         } else {
             Some(DataType::List(Box::new(Field::new(

--- a/src/io/parquet/read/schema/convert.rs
+++ b/src/io/parquet/read/schema/convert.rs
@@ -254,7 +254,7 @@ fn non_repeated_group(
     match (logical_type, converted_type) {
         (Some(GroupLogicalType::List), _) => to_list(fields, parent_name, options),
         (None, Some(GroupConvertedType::List)) => to_list(fields, parent_name, options),
-        (Some(GroupLogicalType::Map), _) => to_list(fields, parent_name, options),
+        (Some(GroupLogicalType::Map), _) => to_map(fields, options),
         (None, Some(GroupConvertedType::Map) | Some(GroupConvertedType::MapKeyValue)) => {
             to_map(fields, options)
         }
@@ -296,11 +296,15 @@ fn to_group_type(
 ) -> Option<DataType> {
     debug_assert!(!fields.is_empty());
     if field_info.repetition == Repetition::Repeated {
-        Some(DataType::List(Box::new(Field::new(
-            &field_info.name,
-            to_struct(fields, options)?,
-            is_nullable(field_info),
-        ))))
+        if (field_info.name == "key_value" || field_info.name == "map") && fields.len() == 2 {
+            to_struct(fields, options)
+        } else {
+            Some(DataType::List(Box::new(Field::new(
+                &field_info.name,
+                to_struct(fields, options)?,
+                is_nullable(field_info),
+            ))))
+        }
     } else {
         non_repeated_group(logical_type, converted_type, fields, parent_name, options)
     }

--- a/src/io/parquet/read/schema/metadata.rs
+++ b/src/io/parquet/read/schema/metadata.rs
@@ -132,13 +132,6 @@ fn apply_original_metadata<'a>(origin_field: &Field, inferred_field: &Field) -> 
                 inferred_field.is_nullable,
             )
         },
-        (DataType::Map(origin_subfield, keys_sorted), DataType::List(inferred_subfield)) => {
-            Field::new(
-                inferred_field.name.clone(),
-                DataType::Map(Box::new(apply_original_metadata(origin_subfield, inferred_subfield)),*keys_sorted),
-                inferred_field.is_nullable,
-            )
-        },
 
         // No matches indicate that the inferred field is consistent with the arrow_schema and doesn't require modifications
         _ => inferred_field.clone(),

--- a/src/io/parquet/read/schema/metadata.rs
+++ b/src/io/parquet/read/schema/metadata.rs
@@ -62,8 +62,6 @@ pub(super) fn parse_key_value_metadata(key_value_metadata: &Option<Vec<KeyValue>
 /// This logic is adapted from a similar function in arrow-cpp
 /// See: `ApplyOriginalMetadata` in https://github.com/apache/arrow/blob/main/cpp/src/parquet/arrow/schema.cc#L976C14-L999
 fn apply_original_metadata<'a>(origin_field: &Field, inferred_field: &Field) -> Field {
-    println!("origin_field: {:?}", origin_field);
-    println!("inferred_field: {:?}", inferred_field);
     let new_field = match (origin_field.data_type(), inferred_field.data_type()) {
         // Wrap inferred field into an Extension type
         (DataType::Extension(_, storage_dtype, _), inferred_dtype) => {


### PR DESCRIPTION
Allow map arrays on parquet files without schema metadata to be parsed as map arrays instead of list arrays.
https://github.com/Eventual-Inc/Daft/pull/1959
